### PR TITLE
Patch pyopenssl broken dependency

### DIFF
--- a/annotators/entity_detection/Dockerfile
+++ b/annotators/entity_detection/Dockerfile
@@ -14,7 +14,7 @@ ENV PORT=$PORT
 COPY ./annotators/entity_detection/requirements.txt /src/requirements.txt
 RUN pip install -r /src/requirements.txt
 
-RUN pip install git+https://github.com/deepmipt/DeepPavlov.git@${COMMIT}
+RUN pip install pyopenssl==22.0.0 git+https://github.com/deepmipt/DeepPavlov.git@${COMMIT}
 
 COPY $SRC_DIR /src
 

--- a/annotators/entity_detection/Dockerfile_new
+++ b/annotators/entity_detection/Dockerfile_new
@@ -19,7 +19,7 @@ RUN pip install -r /src/requirements.txt
 COPY $SRC_DIR /src
 WORKDIR /src
 
-RUN pip install git+https://github.com/deepmipt/DeepPavlov.git@${COMMIT}
+RUN pip install pyopenssl==22.0.0 git+https://github.com/deepmipt/DeepPavlov.git@${COMMIT}
 RUN python -m deeppavlov install $CONFIG
 
 ARG SERVICE_PORT

--- a/annotators/entity_linking/Dockerfile
+++ b/annotators/entity_linking/Dockerfile
@@ -16,7 +16,7 @@ ENV PORT=$PORT
 COPY ./annotators/entity_linking/requirements.txt /src/requirements.txt
 RUN pip install -r /src/requirements.txt
 
-RUN pip install git+https://github.com/deepmipt/DeepPavlov.git@${COMMIT}
+RUN pip install pyopenssl==22.0.0 git+https://github.com/deepmipt/DeepPavlov.git@${COMMIT}
 
 COPY $SRC_DIR /src
 

--- a/annotators/fact_retrieval/Dockerfile
+++ b/annotators/fact_retrieval/Dockerfile
@@ -18,7 +18,7 @@ ENV PORT=$PORT
 COPY ./annotators/fact_retrieval/requirements.txt /src/requirements.txt
 RUN pip install -r /src/requirements.txt
 
-RUN pip install git+https://github.com/deepmipt/DeepPavlov.git@${COMMIT}
+RUN pip install pyopenssl==22.0.0 git+https://github.com/deepmipt/DeepPavlov.git@${COMMIT}
 
 COPY $SRC_DIR /src
 

--- a/services/text_qa/Dockerfile
+++ b/services/text_qa/Dockerfile
@@ -13,7 +13,7 @@ COPY ./requirements.txt /src/requirements.txt
 RUN pip install -r /src/requirements.txt
 
 RUN apt-get update && apt-get install git -y
-RUN pip install git+https://github.com/deepmipt/DeepPavlov.git@${COMMIT}
+RUN pip install pyopenssl==22.0.0 git+https://github.com/deepmipt/DeepPavlov.git@${COMMIT}
 
 COPY . /src
 


### PR DESCRIPTION
Force use of version 22.0.0 to avoid the error: "AttributeError module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK"