### PR TITLE
fix: remove extra logs

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -764,10 +764,8 @@ def get_topics(annotated_utterance, probs=False, default_probs=None, default_lab
         answer_probs, answer_labels = default_probs, default_labels
 
     if probs:
-        logger.info(f"Result in get_topics: {answer_probs}")
         return answer_probs
     else:
-        logger.info(f"Result in get_topics: {answer_labels}")
         return answer_labels
 
 
@@ -862,10 +860,8 @@ def get_intents(annotated_utterance, probs=False, default_probs=None, default_la
         answer_probs, answer_labels = default_probs, default_labels
 
     if probs:
-        logger.info(f"Result in get_intents: {answer_probs}")
         return answer_probs
     else:
-        logger.info(f"Result in get_intents: {answer_labels}")
         return answer_labels
 
 


### PR DESCRIPTION
extra logs were due to the print in `get_intents`. This function is called by `if_chat_about_particular_topic`. And this function is called many times in `common/wiki_skill.py` which is normal. So, just removing logs