### PR TITLE
fix: entity-linking service GPU location

### DIFF
--- a/assistant_dists/dream/test.yml
+++ b/assistant_dists/dream/test.yml
@@ -74,6 +74,8 @@ services:
   entity-linking:
     volumes:
       - "~/.deeppavlov:/root/.deeppavlov"
+    environment:
+      - CUDA_VISIBLE_DEVICES=9
   wiki-parser:
     volumes:
       - "~/.deeppavlov:/root/.deeppavlov"


### PR DESCRIPTION
entity-linking service was located on gpu #0 during tests, that was used by deeppavlov tests.