### PR TITLE
fix: openai dockerfiles

### DIFF
--- a/services/openai_api_lm/Dockerfile
+++ b/services/openai_api_lm/Dockerfile
@@ -8,6 +8,7 @@ RUN pip install -r /src/requirements.txt
 ARG PRETRAINED_MODEL_NAME_OR_PATH
 ENV PRETRAINED_MODEL_NAME_OR_PATH ${PRETRAINED_MODEL_NAME_OR_PATH}
 
-COPY . /src
+COPY services/openai_api_lm /src
+COPY common /src/common
 
 CMD gunicorn --workers=1 server:app -b 0.0.0.0:${SERVICE_PORT} --timeout=300


### PR DESCRIPTION
How to get error:
```
docker compose -f docker-compose.yml -f assistant_dists/deepy_assistant/docker-compose.override.yml up --build openai-api-davinci3
```
This PR allows to run services without dev.yml.