### PR TITLE
fix: deepy base and adv connectors

### DIFF
--- a/assistant_dists/deepy_adv/docker-compose.override.yml
+++ b/assistant_dists/deepy_adv/docker-compose.override.yml
@@ -8,6 +8,8 @@ services:
         rule-based-response-selector:8005, emotion-classification-deepy:8015, dff-program-y-skill:8008, entity-linking-deepy:8075,
         intent-catcher:8014, sentseg:8011"
       WAIT_HOSTS_TIMEOUT: ${WAIT_TIMEOUT:-480}
+    ports:
+      - 4242:4242
 
   spelling-preprocessing:
     env_file: [ .env ]

--- a/assistant_dists/deepy_adv/pipeline_conf.json
+++ b/assistant_dists/deepy_adv/pipeline_conf.json
@@ -107,7 +107,7 @@
                 "connector": {
                     "protocol": "python",
                     "url": "http://emotion-classification-deepy:8015/model",
-                    "class_name": "connectors:BatchConnector"
+                    "class_name": "assistant_dists.deepy_adv.connectors:BatchConnector"
                 },
                 "dialog_formatter": "state_formatters.dp_formatters:hypotheses_list",
                 "response_formatter": "state_formatters.dp_formatters:simple_formatter_service",

--- a/assistant_dists/deepy_base/docker-compose.override.yml
+++ b/assistant_dists/deepy_base/docker-compose.override.yml
@@ -7,6 +7,8 @@ services:
       WAIT_HOSTS: "spelling-preprocessing:8074, harvesters-maintenance-skill:3662, rule-based-response-selector:8005,
         emotion-classification-deepy:8015, dff-program-y-skill:8008"
       WAIT_HOSTS_TIMEOUT: ${WAIT_TIMEOUT:-480}
+    ports:
+      - 4242:4242
 
   spelling-preprocessing:
     env_file: [ .env ]

--- a/assistant_dists/deepy_base/pipeline_conf.json
+++ b/assistant_dists/deepy_base/pipeline_conf.json
@@ -56,7 +56,7 @@
                 "connector": {
                     "protocol": "python",
                     "url": "http://emotion-classification-deepy:8015/model",
-                    "class_name": "connectors:BatchConnector"
+                    "class_name": "assistant_dists.deepy_base.connectors:BatchConnector"
                 },
                 "dialog_formatter": "state_formatters.dp_formatters:hypotheses_list",
                 "response_formatter": "state_formatters.dp_formatters:simple_formatter_service",


### PR DESCRIPTION
For deepy_base, deepy_adv:
- added agent ports mapping,
- fixed `emotion-classification-deepy` connector path.