### PR TITLE
refactor: openai services memory limits

### DIFF
--- a/assistant_dists/deeppavlov_assistant/docker-compose.override.yml
+++ b/assistant_dists/deeppavlov_assistant/docker-compose.override.yml
@@ -88,7 +88,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 100M
+          memory: 500M
         reservations:
           memory: 100M
 

--- a/assistant_dists/deepy_assistant/docker-compose.override.yml
+++ b/assistant_dists/deepy_assistant/docker-compose.override.yml
@@ -89,7 +89,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 100M
+          memory: 500M
         reservations:
           memory: 100M
 

--- a/assistant_dists/dream_persona_openai_prompted/docker-compose.override.yml
+++ b/assistant_dists/dream_persona_openai_prompted/docker-compose.override.yml
@@ -122,7 +122,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 100M
+          memory: 500M
         reservations:
           memory: 100M
 

--- a/assistant_dists/fairytale_assistant/docker-compose.override.yml
+++ b/assistant_dists/fairytale_assistant/docker-compose.override.yml
@@ -122,7 +122,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 100M
+          memory: 500M
         reservations:
           memory: 100M
 

--- a/assistant_dists/life_coaching_assistant/docker-compose.override.yml
+++ b/assistant_dists/life_coaching_assistant/docker-compose.override.yml
@@ -122,7 +122,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 100M
+          memory: 500M
         reservations:
           memory: 100M
 

--- a/assistant_dists/multiskill_ai_assistant/docker-compose.override.yml
+++ b/assistant_dists/multiskill_ai_assistant/docker-compose.override.yml
@@ -126,7 +126,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 100M
+          memory: 500M
         reservations:
           memory: 100M
 

--- a/assistant_dists/universal_prompted_assistant/docker-compose.override.yml
+++ b/assistant_dists/universal_prompted_assistant/docker-compose.override.yml
@@ -141,7 +141,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 100M
+          memory: 500M
         reservations:
           memory: 100M
 
@@ -160,7 +160,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 100M
+          memory: 500M
         reservations:
           memory: 100M
 
@@ -179,7 +179,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 100M
+          memory: 500M
         reservations:
           memory: 100M
 
@@ -198,7 +198,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 100M
+          memory: 500M
         reservations:
           memory: 100M
 
@@ -217,7 +217,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 100M
+          memory: 500M
         reservations:
           memory: 100M
 


### PR DESCRIPTION
OpenAI services memory limitations increased to handle ~100 simultanious requests.