### PR TITLE
fix: ImportError due to Werkzeug release

### DIFF
--- a/annotators/asr/requirements.txt
+++ b/annotators/asr/requirements.txt
@@ -4,4 +4,4 @@ gunicorn==19.9.0
 requests==2.28.2
 sentry-sdk==1.19.1
 jinja2<=3.1.2
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0

--- a/annotators/entity_storer/requirements.txt
+++ b/annotators/entity_storer/requirements.txt
@@ -9,4 +9,4 @@ nltk==3.5
 click>=8.0
 requests==2.28.2
 jinja2<=3.0.3
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0

--- a/annotators/fact_random/requirements.txt
+++ b/annotators/fact_random/requirements.txt
@@ -4,4 +4,4 @@ itsdangerous==2.0.1
 gunicorn==20.1.0
 requests==2.28.2
 jinja2<=3.0.3
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0

--- a/annotators/midas_predictor/requirements.txt
+++ b/annotators/midas_predictor/requirements.txt
@@ -7,4 +7,4 @@ sentry-sdk[asgi]==1.19.1
 itsdangerous==2.0.1
 numpy==1.24.2
 jinja2<=3.0.3
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0

--- a/annotators/news_api/requirements.txt
+++ b/annotators/news_api/requirements.txt
@@ -7,4 +7,4 @@ numpy==1.24.2
 nltk==3.2.5
 prometheus_client
 jinja2<=3.0.3
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0

--- a/annotators/prompt_selector/requirements.txt
+++ b/annotators/prompt_selector/requirements.txt
@@ -5,5 +5,5 @@ sentry-sdk==1.19.1
 requests==2.28.2
 click<=8.0.4
 jinja2<=3.1.2
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0
 numpy>=1.17.2

--- a/annotators/relative_persona_extractor/requirements.txt
+++ b/annotators/relative_persona_extractor/requirements.txt
@@ -5,5 +5,5 @@ sentry-sdk==1.19.1
 requests==2.28.2
 click<=8.0.4
 jinja2<=3.0.3
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0
 numpy==1.24.2

--- a/annotators/topic_recommendation/requirements.txt
+++ b/annotators/topic_recommendation/requirements.txt
@@ -5,4 +5,4 @@ requests==2.28.2
 sentry-sdk==1.19.1
 numpy==1.24.2
 jinja2<=3.0.3
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0

--- a/annotators/user_persona_extractor/requirements.txt
+++ b/annotators/user_persona_extractor/requirements.txt
@@ -4,4 +4,4 @@ gunicorn==20.1.0
 requests==2.28.2
 sentry-sdk==1.19.1
 jinja2<=3.0.3
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0

--- a/annotators/wiki_parser/requirements.txt
+++ b/annotators/wiki_parser/requirements.txt
@@ -4,5 +4,5 @@ itsdangerous==2.0.1
 gunicorn==20.1.0
 requests==2.28.2
 jinja2<=3.0.3
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0
 pybind11==2.10.4

--- a/skills/eliza/requirements.txt
+++ b/skills/eliza/requirements.txt
@@ -4,4 +4,4 @@ gunicorn==19.9.0
 requests==2.22.0
 sentry-sdk<=1.19.1
 jinja2<=3.0.3
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0

--- a/skills/emotion_skill/requirements.txt
+++ b/skills/emotion_skill/requirements.txt
@@ -7,4 +7,4 @@ gunicorn==20.1.0
 ahocorapy==1.6.2
 nltk==3.2.5
 jinja2<=3.0.3
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0

--- a/skills/factoid_qa/requirements.txt
+++ b/skills/factoid_qa/requirements.txt
@@ -8,5 +8,5 @@ sentry-sdk==1.19.1
 spacy>=3.5.2
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.5.0/en_core_web_sm-3.5.0.tar.gz#egg=en_core_web_sm==3.5.0
 jinja2<=3.0.3
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0
 importlib-metadata<5.0

--- a/skills/knowledge_grounding_skill/requirements.txt
+++ b/skills/knowledge_grounding_skill/requirements.txt
@@ -6,4 +6,4 @@ numpy==1.24.2
 requests==2.28.2
 sentry-sdk==1.19.1
 jinja2<=3.0.3
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0

--- a/skills/meta_script_skill/requirements.txt
+++ b/skills/meta_script_skill/requirements.txt
@@ -9,6 +9,6 @@ spacy==3.5.1
 importlib_metadata<5
 nltk[twitter]==3.2.5
 jinja2<=3.0.3
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0
 typing-inspect==0.8.0
 typing_extensions==4.5.0

--- a/skills/misheard_asr/requirements.txt
+++ b/skills/misheard_asr/requirements.txt
@@ -4,5 +4,5 @@ gunicorn==19.9.0
 requests==2.28.2
 sentry-sdk==1.19.1
 jinja2<=3.1.2
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0
 numpy==1.24.2

--- a/skills/news_api_skill/requirements.txt
+++ b/skills/news_api_skill/requirements.txt
@@ -7,6 +7,6 @@ gunicorn==20.1.0
 numpy==1.24.2
 spacy==3.5.1
 jinja2<=3.0.3
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0
 nltk==3.2.5
 prometheus_client==0.16.0

--- a/skills/personal_info_skill/requirements.txt
+++ b/skills/personal_info_skill/requirements.txt
@@ -5,4 +5,4 @@ requests==2.28.2
 numpy==1.24.2
 sentry-sdk==1.19.1
 jinja2<=3.1.2
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0

--- a/skills/small_talk_skill/requirements.txt
+++ b/skills/small_talk_skill/requirements.txt
@@ -7,4 +7,4 @@ gunicorn==20.1.0
 numpy==1.24.2
 spacy==3.5.1
 jinja2<=3.0.3
-Werkzeug>=2.2.2
+Werkzeug>=2.2.2,<3.0


### PR DESCRIPTION
After Werkzeug 3.0 release appeared an error
```
ImportError: cannot import name 'url_quote' from 'werkzeug.urls'
```
This PR fixes this error.